### PR TITLE
Correct LICENSE - Copyright cannot be edited as was done

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2019 Stefanie Molin
 Copyright (c) 2021 William Vera
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='stock_analysis',
     version='0.2',
     description='Classes for technical analysis of stocks.',
-    author='William Vera',
+    author='Stefanie Molin, William Vera',
     license='MIT',
     url='https://github.com/will-i-amv/stock-analysis',
     packages=['stock_analysis'],


### PR DESCRIPTION
Hi @will-i-amv,

I'm correcting your LICENSE file in your fork of my repo to restore the original copyright of the content, which per the license cannot be removed. The license states that the copyright notice must appear in all copies and derivative works:

>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

You can find more information [here](https://opensource.stackexchange.com/questions/4439/how-to-deal-with-licences-after-forking-a-project#:~:text=No%2C%20you%20are%20not%20allowed,substantial%20portions%20of%20the%20Software.)